### PR TITLE
(#2) Добавлен CI для PHP 8.0

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,25 @@
+name: Run tests
+on:
+  pull_request:
+    branches: [ master ]
+
+env:
+  COMPOSE_PROJECT_NAME: yii2-queue-mailer
+  COMPOSE_FILE: tests/docker/docker-compose.yml
+jobs:
+  phpunit:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ 80 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: make build
+
+      - name: Run tests for PHP ${{ matrix.php }}
+        run: make test${{ matrix.php }}

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,9 @@ down:
 
 start:
 	COMPOSE_FILE=tests/docker/docker-compose.yml docker-compose up -d
+
+test: test80
+test80:
+	COMPOSE_FILE=tests/docker/docker-compose.yml docker-compose build --pull php80
+	COMPOSE_FILE=tests/docker/docker-compose.yml docker-compose run php80 vendor/bin/phpunit --verbose --colors=always
+	COMPOSE_FILE=tests/docker/docker-compose.yml docker-compose down

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,19 +1,19 @@
 version: '3.8'
 
 services:
-  php-80:
+  php80:
     container_name: mail_queue
     hostname: mail_queue
     build: ./php/8.0
     volumes:
+      - ./runtime/.composer80:/root/.composer
       - ../..:/var/www
+    dns:
+      - 8.8.8.8
+      - 4.4.4.4
     networks:
       - mail-queue-network
 
 networks:
   mail-queue-network:
     driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.250.0/28

--- a/tests/docker/php/8.0/Dockerfile
+++ b/tests/docker/php/8.0/Dockerfile
@@ -1,15 +1,14 @@
-FROM --platform=linux/amd64 php:8.0.20-fpm-alpine
+FROM --platform=linux/amd64 php:8.0.21-fpm-alpine
 
-RUN apk add git unzip zlib-dev libzip-dev
+RUN apk add unzip zlib-dev libzip-dev
 
-RUN docker-php-ext-install bcmath zip
+RUN docker-php-ext-install zip
 
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php composer-setup.php
-RUN php -r "unlink('composer-setup.php');"
-RUN mv composer.phar /usr/local/bin/composer
-RUN curl --remote-name --time-cond ./php/cacert.pem https://curl.se/ca/cacert.pem
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 WORKDIR /var/www
+
+ENTRYPOINT ["sh", "tests/docker/php/entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/tests/docker/php/entrypoint.sh
+++ b/tests/docker/php/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+flock tests/runtime/composer-install.lock composer update --prefer-dist --no-interaction
+
+php --version
+set -x
+exec "$@"


### PR DESCRIPTION
На всякий случай напишу: `runs-on: ubuntu-latest` это надо обязательно указывать для прохождения валидации схемы. Выбора alpine там нет, но нам это не так важно